### PR TITLE
Fix banner crash and not showing

### DIFF
--- a/Source/AmazonPublisherServicesAdAdapter+Banners.swift
+++ b/Source/AmazonPublisherServicesAdAdapter+Banners.swift
@@ -31,6 +31,7 @@ extension AmazonPublisherServicesAdAdapter {
             // Fetch the creative from the mediation hints.
             let adLoader = DTBAdBannerDispatcher(adFrame: frame, delegate: self)
             adLoader.fetchBannerAd(withParameters: mediationHints)
+            self.adLoader = adLoader
         }
     }
 }

--- a/Source/AmazonPublisherServicesAdAdapter.swift
+++ b/Source/AmazonPublisherServicesAdAdapter.swift
@@ -24,6 +24,9 @@ final class AmazonPublisherServicesAdAdapter: NSObject, PartnerAdAdapter {
     /// Instance of the prebidding controller.
     let prebiddingController: APSPreBiddingController
 
+    /// The APS ad dispatcher instance used to load an ad. We have strong reference here to keep it alive while the loading is ongoing.
+    var adLoader: DTBAdDispatcher?
+    
     /// The completion handler to notify Helium of ad show completion result.
     var loadCompletion: ((Result<PartnerAd, Error>) -> Void)?
 


### PR DESCRIPTION
APS banners were crashing due to being used on a background thread.
Also the wrong object was passed as PartnerAd.ad—the loader instead of the adView—which prevented banners from every showing.