### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/AmazonPublisherServicesAdapterBannerAd.swift
+++ b/Source/AmazonPublisherServicesAdapterBannerAd.swift
@@ -69,7 +69,7 @@ extension AmazonPublisherServicesAdapterBannerAd: DTBAdBannerDispatcherDelegate 
     }
 
     func adFailed(toLoad banner: UIView?, errorCode: Int) {
-        let error = error(.loadFailureUnknown, description: "\(errorCode)")
+        let error = partnerError(errorCode)
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil

--- a/Source/AmazonPublisherServicesAdapterInterstitialAd.swift
+++ b/Source/AmazonPublisherServicesAdapterInterstitialAd.swift
@@ -81,7 +81,7 @@ extension AmazonPublisherServicesAdapterInterstitialAd: DTBAdInterstitialDispatc
     }
 
     func interstitial(_ interstitial: DTBAdInterstitialDispatcher?, didFailToLoadAdWith errorCode: DTBAdErrorCode) {
-        let error = error(.loadFailureUnknown, description: "\(errorCode)")
+        let error = partnerError(errorCode.rawValue)
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
