### PR TITLE
HB-5057: import ChartboostMediationSDK instead of HeliumSdk

### DIFF
--- a/Source/APSPreBiddingController.swift
+++ b/Source/APSPreBiddingController.swift
@@ -8,8 +8,8 @@
 //  ChartboostHeliumAdapterAmazonPublisherServices
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 
 /// Managers all the `APSPreBidder` objects.
 class APSPreBiddingController {

--- a/Source/AmazonPublisherServicesAdapter.swift
+++ b/Source/AmazonPublisherServicesAdapter.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterAmazonPublisherServices
 //
 
-import Foundation
-import HeliumSdk
+import ChartboostMediationSDK
 import DTBiOSSDK
+import Foundation
 import UIKit
 
 /// The Helium Amazon Publisher Services adapter.

--- a/Source/AmazonPublisherServicesAdapterAd.swift
+++ b/Source/AmazonPublisherServicesAdapterAd.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterAmazonPublisherServices
 //
 
-import Foundation
-import HeliumSdk
+import ChartboostMediationSDK
 import DTBiOSSDK
+import Foundation
 import UIKit
 
 /// Base class for Helium Amazon Publisher Services adapter ads.

--- a/Source/AmazonPublisherServicesAdapterBannerAd.swift
+++ b/Source/AmazonPublisherServicesAdapterBannerAd.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterAmazonPublisherServices
 //
 
-import Foundation
-import HeliumSdk
+import ChartboostMediationSDK
 import DTBiOSSDK
+import Foundation
 
 /// The Helium Amazon Publisher Services adapter banner ad.
 final class AmazonPublisherServicesAdapterBannerAd: AmazonPublisherServicesAdapterAd, PartnerAd {

--- a/Source/AmazonPublisherServicesAdapterInterstitialAd.swift
+++ b/Source/AmazonPublisherServicesAdapterInterstitialAd.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterAmazonPublisherServices
 //
 
-import Foundation
-import HeliumSdk
+import ChartboostMediationSDK
 import DTBiOSSDK
+import Foundation
 
 /// The Helium Amazon Publisher Services adapter interstitial ad.
 final class AmazonPublisherServicesAdapterInterstitialAd: AmazonPublisherServicesAdapterAd, PartnerAd {


### PR DESCRIPTION
This is a companion PR of https://github.com/ChartBoost/ios-helium-sdk/pull/942.

Discussed with Dani and decided to merge the tedious adapter PR's without code review to speed up the whole rebranding process.