### PR TITLE
HB-5214: Guard against integer underflow when mapping errors

### DIFF
--- a/Source/AmazonPublisherServicesAdapter.swift
+++ b/Source/AmazonPublisherServicesAdapter.swift
@@ -198,8 +198,13 @@ final class AmazonPublisherServicesAdapter: PartnerAdapter {
     /// Only implement if the partner SDK provides its own list of error codes that can be mapped to Chartboost Mediation's.
     /// If some case cannot be mapped return `nil` to let Chartboost Mediation choose a default error code.
     func mapPrebidError(_ error: Error) -> ChartboostMediationError.Code? {
-        let code = DTBAdError(UInt32((error as NSError).code))
-        switch code {
+        guard let errorCode = UInt32(exactly: (error as NSError).code) else {
+            return nil
+        }
+
+        let dtbErrorCode = DTBAdError(errorCode)
+
+        switch dtbErrorCode {
         case NETWORK_ERROR:
             return .prebidFailureNetworkingError
         case NETWORK_TIMEOUT:


### PR DESCRIPTION
I was getting an SSL error with the error code `-1200`, which was causing a crash due to integer underflow. This change will protect against both underflow and overflow. This change has been made to all adapters that convert to `Int32` or `UInt32`.