### PR TITLE
HB-5244: schema compatibility for pre and post rebranding property name

### DIFF
--- a/Source/APSPreBidderConfiguration.swift
+++ b/Source/APSPreBidderConfiguration.swift
@@ -14,7 +14,11 @@ struct APSPreBidderConfiguration: Codable {
     }
     
     /// Chartboost Mediation placement name.
-    let chartboostPlacement: String
+    let chartboostPlacement: String?
+
+    /// Legacy Chartboost Mediation (Helium) placement name for compatibility with backend schema.
+    @available(swift, deprecated: 4.0, message: "Use `chartboostPlacement` if it's not nil.")
+    let heliumPlacement: String?
     
     /// Amazon slot UUID associated with the Chartboost Mediation placement name.
     let partnerPlacement: String

--- a/Source/APSPreBiddingController.swift
+++ b/Source/APSPreBiddingController.swift
@@ -66,7 +66,11 @@ class APSPreBiddingController {
                 }
 
                 // Capture the prebidder
-                partialResult[bidderConfiguration.chartboostPlacement] = bidder
+                if let chartboostPlacement = bidderConfiguration.chartboostPlacement {
+                    partialResult[chartboostPlacement] = bidder
+                } else if let heliumPlacement = bidderConfiguration.heliumPlacement {
+                    partialResult[heliumPlacement] = bidder // backward compatibility
+                }
             }
         }
     }


### PR DESCRIPTION
Before rebranding: "helium_placement"
After rebranding: "chartboost_placement"

See https://chartboost.slack.com/archives/C019BTYC9MH/p1676465321834829

This is based on Dani's PR https://github.com/ChartBoost/chartboost-mediation-ios-adapter-amazon-publisher-services/pull/29.

How to test
--------
Run the Canary app, and search the console log for `initialization: [partner = amazon_aps` with `isSuccess = true`. 

Success example:
```
[Helium SDK] Metrics data for initialization: [partner = amazon_aps, start = 1676490972388, end = 1676490973272, duration = 883, isSuccess = true]
```

Failure example:
```
[Helium SDK] Metrics data for initialization: [partner = amazon_aps, start = 1676490396701, end = 1676490397588, duration = 887, chartboostMediationError = CM_INITIALIZATION_FAILURE_INVALID_CREDENTIALS, chartboostMediationErrorCode = CM_105, errorMessage = Partner initialization has failed., isSuccess = false]
```