### PR TITLE
Remove deprecation which would lead to warnings and lint failures

### DIFF
--- a/Source/APSPreBidderConfiguration.swift
+++ b/Source/APSPreBidderConfiguration.swift
@@ -17,7 +17,7 @@ struct APSPreBidderConfiguration: Codable {
     let chartboostPlacement: String?
 
     /// Legacy Chartboost Mediation (Helium) placement name for compatibility with backend schema.
-    @available(swift, deprecated: 4.0, message: "Use `chartboostPlacement` if it's not nil.")
+    /// We should be able to remove this once backend is updated.
     let heliumPlacement: String?
     
     /// Amazon slot UUID associated with the Chartboost Mediation placement name.


### PR DESCRIPTION
`pod lint` will fail in our nightly workflow and in future smoke test / release workflows due to the warning raised by the compiler on the line that uses the deprecated `heliumPlacement` property.
I think the best is to just remove the deprecation.
I left a comment so we remember this property may be removed in a next version.