### PR TITLE
HB-5462: Support new ad format cases without warnings

### DIFF
--- a/Source/AmazonPublisherServicesAdapter.swift
+++ b/Source/AmazonPublisherServicesAdapter.swift
@@ -186,7 +186,7 @@ final class AmazonPublisherServicesAdapter: PartnerAdapter {
             throw error(.loadFailureUnsupportedAdFormat)
         case .banner:
             return AmazonPublisherServicesAdapterBannerAd(adapter: self, request: request, delegate: delegate, prebiddingController: prebiddingController)
-        @unknown default:
+        default:
             throw error(.loadFailureUnsupportedAdFormat)
         }
     }


### PR DESCRIPTION
Removed the  keyword from the default case when switching on ad format, preventing warnings when new formats are introduced on newer Chartboost Mediation SDK versions.\nThe plan is to just merge this to main, and create new patch releases later on with the first 4.3 RCs with whatever the latest adapter version is.