### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
   release-adapter:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2
         with:
           allow-warnings: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,6 +12,6 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2
         with:
           allow-warnings: true

--- a/Source/AmazonPublisherServicesAdapter.swift
+++ b/Source/AmazonPublisherServicesAdapter.swift
@@ -12,18 +12,26 @@ import UIKit
 final class AmazonPublisherServicesAdapter: PartnerAdapter {
     
     /// The version of the partner SDK.
-    var partnerSDKVersion: String { APS.version() }
+    var partnerSDKVersion: String {
+        AmazonPublisherServicesAdapterConfiguration.partnerSDKVersion
+    }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.4.9.0.1"
-    
+    var adapterVersion: String {
+        AmazonPublisherServicesAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "amazon_aps"
-    
+    var partnerID: String {
+        AmazonPublisherServicesAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Amazon Publisher Services"
+    var partnerDisplayName: String {
+        AmazonPublisherServicesAdapterConfiguration.partnerDisplayName
+    }
 
     /// A delegate that performs pre-bidding operations by integrating directly with the Amazon Publisher Services SDK.
     ///

--- a/Source/AmazonPublisherServicesAdapterConfiguration.swift
+++ b/Source/AmazonPublisherServicesAdapterConfiguration.swift
@@ -9,6 +9,22 @@ import os.log
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class AmazonPublisherServicesAdapterConfiguration: NSObject {
     
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        APS.version()
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.4.9.0.1"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "amazon_aps"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "Amazon Publisher Services"
+
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.amazon_aps", category: "Configuration")
 
     /// Flag that can optionally be set to enable the partner's test mode.

--- a/Source/AmazonPublisherServicesAdapterConfiguration.swift
+++ b/Source/AmazonPublisherServicesAdapterConfiguration.swift
@@ -29,12 +29,13 @@ import os.log
 
     /// Flag that can optionally be set to enable the partner's test mode.
     /// Disabled by default.
-    @objc public static var testMode: Bool = false {
-        didSet {
-            DTBAds.sharedInstance().testMode = testMode
-            if #available(iOS 12.0, *) {
-                os_log(.debug, log: log, "Amazon Publishing Services SDK test mode set to %{public}s", "\(testMode)")
-            }
+    @objc public static var testMode: Bool {
+        get {
+            DTBAds.sharedInstance().testMode
+        }
+        set {
+            DTBAds.sharedInstance().testMode = newValue
+            os_log(.debug, log: log, "Amazon Publishing Services SDK test mode set to %{public}s", "\(testMode)")
         }
     }
     
@@ -43,9 +44,7 @@ import os.log
     @objc public static var verboseLogging: Bool = false {
         didSet {
             DTBAds.sharedInstance().setLogLevel(DTBLogLevelAll)
-            if #available(iOS 12.0, *) {
-                os_log(.debug, log: log, "Amazon Publishing Services SDK verbose logging set to %{public}s", "\(verboseLogging)")
-            }
+            os_log(.debug, log: log, "Amazon Publishing Services SDK verbose logging set to %{public}s", "\(verboseLogging)")
         }
     }
 

--- a/Source/AmazonPublisherServicesAdapterConfiguration.swift
+++ b/Source/AmazonPublisherServicesAdapterConfiguration.swift
@@ -10,20 +10,20 @@ import os.log
 @objc public class AmazonPublisherServicesAdapterConfiguration: NSObject {
     
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         APS.version()
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.4.9.0.1"
+    @objc public static let adapterVersion = "4.4.9.0.1"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "amazon_aps"
+    @objc public static let partnerID = "amazon_aps"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "Amazon Publisher Services"
+    @objc public static let partnerDisplayName = "Amazon Publisher Services"
 
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.amazon_aps", category: "Configuration")
 


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.