### PR TITLE
HB-7607: Replace duplicated code with call to helper method

### DIFF
--- a/Source/AmazonPublisherServicesAdapterBannerAd.swift
+++ b/Source/AmazonPublisherServicesAdapterBannerAd.swift
@@ -40,7 +40,8 @@ final class AmazonPublisherServicesAdapterBannerAd: AmazonPublisherServicesAdapt
         }
 
         // Fail if we cannot fit a fixed size banner in the requested size.
-        guard let loadedSize = fixedBannerSize(for: request.bannerSize) else {
+        guard let requestedSize = request.bannerSize,
+              let loadedSize = BannerSize.largestStandardFixedSizeThatFits(in: requestedSize)?.size else {
             let error = error(.loadFailureInvalidBannerSize)
             log(.loadFailed(error))
             return completion(.failure(error))
@@ -89,25 +90,5 @@ extension AmazonPublisherServicesAdapterBannerAd: DTBAdBannerDispatcherDelegate 
     func impressionFired() {
         log(.didTrackImpression)
         delegate?.didTrackImpression(self, details: [:]) ?? log(.delegateUnavailable)
-    }
-}
-
-// MARK: - Helpers
-extension AmazonPublisherServicesAdapterBannerAd {
-    private func fixedBannerSize(for requestedSize: BannerSize?) -> CGSize? {
-        guard let requestedSize else {
-            return IABStandardAdSize
-        }
-        let sizes = [IABLeaderboardAdSize, IABMediumAdSize, IABStandardAdSize]
-        // Find the largest size that can fit in the requested size.
-        for size in sizes {
-            // If height is 0, the pub has requested an ad of any height, so only the width matters.
-            if requestedSize.size.width >= size.width &&
-                (size.height == 0 || requestedSize.size.height >= size.height) {
-                return size
-            }
-        }
-        // The requested size cannot fit any fixed size banners.
-        return nil
     }
 }

--- a/Source/AmazonPublisherServicesAdapterConfiguration.swift
+++ b/Source/AmazonPublisherServicesAdapterConfiguration.swift
@@ -17,7 +17,7 @@ import os.log
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc public static let adapterVersion = "4.4.9.0.1"
+    @objc public static let adapterVersion = "5.4.9.0.1"
 
     /// The partner's unique identifier.
     @objc public static let partnerID = "amazon_aps"


### PR DESCRIPTION
Many adapters have similar code for finding the largest standard banner size that will fit within requested dimensions. This can now be replaced with BannerSize.largestStandardFixedSizeThatFits(in:)