### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,27 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+All official releases can be found on this repository's [releases page](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-amazon-publisher-services/releases).
+
 ### 5.4.10.0.0
 - This version of the adapter has been certified with AmazonPublisherServicesSDK 4.10.0.
 
-### 5.4.9.0.1
+### 4.4.9.0.2
 - Fix a retain cycle with the prebidder.
 - This version of the adapter has been certified with AmazonPublisherServicesSDK 4.9.0.
 
-### 5.4.9.0.0
-- The minimum deployment target compatible with this adapter is now iOS 13.
-- This version of the adapter has been certified with ChartboostMediationSDK 5.0.0.
-- This version of the adapter has been certified with AmazonPublisherServicesSDK 4.9.0.
-
-### 4.4.9.0.2
+### 5.4.9.0.1
 - Fix a retain cycle with the prebidder.
 - This version of the adapter has been certified with AmazonPublisherServicesSDK 4.9.0.
 
 ### 4.4.9.0.1
 - Prevent `onPreBid(request:completion:)` delegate calls from being made for prebids without
 an associated APS placement.
+- This version of the adapter has been certified with AmazonPublisherServicesSDK 4.9.0.
+
+### 5.4.9.0.0
+- The minimum deployment target compatible with this adapter is now iOS 13.
+- This version of the adapter has been certified with ChartboostMediationSDK 5.0.0.
 - This version of the adapter has been certified with AmazonPublisherServicesSDK 4.9.0.
 
 ### 4.4.9.0.0


### PR DESCRIPTION
Retroactively update the CHANGELOG to include a link to the official releases page on Github and with Mediation 4 releases (if necessary).